### PR TITLE
Fix attribute error by changing k.value_name to k.name

### DIFF
--- a/lib/glib.py
+++ b/lib/glib.py
@@ -190,7 +190,7 @@ def init_user_dir_caches():
         k = GLib.UserDirectory(i)
         logger.debug(
             "Init g_get_user_special_dir(%s): %r",
-            k.value_name,
+            k.name,
             get_user_special_dir(k),
         )
 


### PR DESCRIPTION
k.value_name was resulting in attribute error.
Changing it to k.name resolves it.

References:
https://github.com/mypaint/mypaint/issues/1292